### PR TITLE
feat: delete tenantのフロントを実装

### DIFF
--- a/frontend/console/src/components/TenantList.tsx
+++ b/frontend/console/src/components/TenantList.tsx
@@ -6,10 +6,12 @@ export const TenantList = ({
   tenants,
   isLoading,
   isError,
+  onDelete,
 }: {
   tenants: Tenant[];
   isLoading: boolean;
   isError: boolean;
+  onDelete?: (tenantId: string, tenantName: string) => void;
 }) => {
   const navigate = useNavigate();
   if (isLoading) {
@@ -51,7 +53,7 @@ export const TenantList = ({
               </div>
               {tenant.description && <p className="mt-1 text-sm text-gray-600">{tenant.description}</p>}
             </div>
-            <div>
+            <div className="flex space-x-2">
               <button
                 onClick={() => navigate(`/tenants/${tenant.id}/assign-room`)}
                 className="inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:outline-none"
@@ -66,6 +68,22 @@ export const TenantList = ({
                 </svg>
                 Room割り当て
               </button>
+              {onDelete && (
+                <button
+                  onClick={() => onDelete(tenant.id, tenant.name)}
+                  className="inline-flex items-center rounded-md border border-red-300 bg-white px-3 py-2 text-sm font-medium text-red-700 hover:bg-red-50 focus:ring-2 focus:ring-red-500 focus:ring-offset-2 focus:outline-none"
+                >
+                  <svg className="mr-1.5 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                    />
+                  </svg>
+                  削除
+                </button>
+              )}
             </div>
           </div>
         </li>

--- a/frontend/console/src/libs/query.ts
+++ b/frontend/console/src/libs/query.ts
@@ -7,6 +7,7 @@ import {
   getAllTenants,
   getTenantById,
 } from '../../../gen/src/keyhub/console/v1/console-ConsoleService_connectquery';
+import { deleteTenant } from '../../../gen/src/keyhub/console/v1/tenant-ConsoleService_connectquery';
 import {
   createRoom,
   getAllRooms,
@@ -79,4 +80,8 @@ export const useMutationCreateKey = () => {
 
 export const useQueryGetKeysByRoom = (roomId: string) => {
   return useQuery(getKeysByRoom, { roomId });
+};
+
+export const useMutationDeleteTenant = () => {
+  return useMutation(deleteTenant);
 };


### PR DESCRIPTION
delete tenanのフロントエンドを実装しました。
dbの権限？で実際には動作できてないです。

エラー
```bssh
Dec 12 17:45:42.791 ERR sentry/sentry.go:116 request failed due to server error error="internal: failed to delete a tenant by id from repository: failed to Queries: failed to delete a tenant by id from repository: ERROR: permission denied for table tenants (SQLSTATE 42501)" code=internal event_id=50728995955a446f8b6bce7eced8dbad
```

サーバー側で使ってるユーザーにdeleteの権限がないっぽくて、migrateinで
```sql
GRANT DELETE ON TABLE tenants TO keyhub;
```
で許可を与える感じですか？
この辺ぶっ壊しそうでこわい



