### PR TITLE
fix: gen-lintのCIからbuf dep updateを削除

### DIFF
--- a/.github/workflows/gen-lint.yaml
+++ b/.github/workflows/gen-lint.yaml
@@ -61,8 +61,6 @@ jobs:
             go-build-cache-v2-${{runner.os}}-${{runner.arch}}-
       - run: gofmt -w .
         working-directory: ./backend
-      - run: buf dep update
-        working-directory: ./proto
       - run: buf generate
         working-directory: ./proto
       - run: git diff --exit-code


### PR DESCRIPTION
## 概要
`Generated files Lint`（gen-lint）CIが BSR への接続障害で失敗していた問題を修正します。closes #80

## 背景・原因
- 失敗ステップは `buf dep update`（proto の依存を BSR からダウンロードして `buf.lock` を更新するコマンド）。
- エラー: `Failure: the server hosted at that remote is unavailable.` — BSR への一時的な接続不能が原因。
- このステップは生成物の最新性を検証するCIの目的には不要で、依存を意図せず更新して差分を生む要因にもなる。

## 変更点
- `.github/workflows/gen-lint.yaml` から `buf dep update` ステップを削除。

## 備考 / 確認事項
- `buf generate` はコミット済みの `proto/buf.lock`（依存を digest 付きでピン留め）から依存を解決できるため、`buf dep update` がなくても動作する。ローカルで `buf generate` の正常動作を確認済み。